### PR TITLE
Only mount che rest api when it is neccessary

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -110,3 +110,9 @@ const (
 	// Policy on webhook failure
 	MutateWebhookFailurePolicy = v1beta1.Fail
 )
+
+// constants for workspace controller
+const (
+	// The ide of theia editor in devfile
+	TheiaEditorID = "eclipse/che-theia"
+)


### PR DESCRIPTION
### What does this PR do?
This PR makes it so that the che rest api's are only mounted when neccessary. I.e. when theia is the editor.

Not sure if I should be trying to merge it against this branch or if I should just wait until the che-workspace-operator rework PR is merged 🤷‍♂ 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15790

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Created cloud shell workspace and looked to see which containers were running and that che-rest-api container wasn't there. Then created test workspace with theia inside and looked to see that che-rest-api was created.