### PR TITLE
Deploy registry if needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PULL_POLICY ?= Always
 WEBHOOK_ENABLED ?= false
 DEFAULT_ROUTING ?= basic
 ADMIN_CTX ?= ""
+REGISTRY_ENABLED ?= true
 
 all: help
 
@@ -33,12 +34,14 @@ _create_namespace:
 	$(TOOL) create namespace $(NAMESPACE) || true
 
 _deploy_registry:
+ifeq ($(REGISTRY_ENABLED),true)
 	$(TOOL) apply -f ./deploy/registry/local
 ifeq ($(TOOL),oc)
 	$(TOOL) apply -f ./deploy/registry/local/os
 else
 	sed -i "s|192.168.99.100|$(CLUSTER_IP)|g" ./deploy/registry/local/k8s/ingress.yaml
 	$(TOOL) apply -f ./deploy/registry/local/k8s
+endif
 endif
 
 _set_registry_url:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The repository contains a Makefile; building and deploying can be configured via
 | `WEBHOOK_ENABLED` | Whether webhooks should be enabled in the deployment | `false` |
 | `DEFAULT_ROUTING` | Default routingClass to apply to workspaces that don't specify one | `basic` |
 | `ADMIN_CTX` | Kubectx entry that should be used during work with cluster. The current will be used if omitted |-|
+| `REGISTRY_ENABLED` | Whether the plugin registry should be deployed | `true` |
 
 The makefile supports the following rules:
 

--- a/pkg/adaptor/plugin.go
+++ b/pkg/adaptor/plugin.go
@@ -14,16 +14,21 @@ package adaptor
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/common"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
+	registry "github.com/che-incubator/che-workspace-operator/pkg/internal_registry"
 	metadataBroker "github.com/eclipse/che-plugin-broker/brokers/metadata"
 	brokerModel "github.com/eclipse/che-plugin-broker/model"
 	"github.com/eclipse/che-plugin-broker/utils"
 	corev1 "k8s.io/api/core/v1"
-	"strconv"
-	"strings"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var log = logf.Log.WithName("plugin")
 
 func AdaptPluginComponents(workspaceId, namespace string, devfileComponents []v1alpha1.ComponentSpec) ([]v1alpha1.ComponentDescription, *corev1.ConfigMap, error) {
 	var components []v1alpha1.ComponentDescription
@@ -199,6 +204,7 @@ func adaptVolumeMountsFromBroker(workspaceId string, brokerContainer brokerModel
 
 func getMetasForComponents(components []v1alpha1.ComponentSpec) (metas []brokerModel.PluginMeta, aliases map[string]string, err error) {
 	defaultRegistry := config.ControllerCfg.GetPluginRegistry()
+	internalRegistry := registry.InternalRegistry()
 	ioUtils := utils.New()
 	aliases = map[string]string{}
 	for _, component := range components {
@@ -206,7 +212,15 @@ func getMetasForComponents(components []v1alpha1.ComponentSpec) (metas []brokerM
 			return nil, nil, fmt.Errorf("cannot adapt non-plugin or editor type component %s in plugin adaptor", component.Type)
 		}
 		fqn := getPluginFQN(component)
-		meta, err := utils.GetPluginMeta(fqn, defaultRegistry, ioUtils)
+		var meta *brokerModel.PluginMeta
+		// delegate to the internal registry, if found there then use that
+		if val, ok := internalRegistry[fqn.ID]; ok {
+			log.Info(fmt.Sprintf("Grabbing the meta.yaml for %s from the internal registry", fqn.ID))
+			meta = &val
+		} else {
+			meta, err = utils.GetPluginMeta(fqn, defaultRegistry, ioUtils)
+		}
+
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/adaptor/plugin.go
+++ b/pkg/adaptor/plugin.go
@@ -213,7 +213,7 @@ func getMetasForComponents(components []v1alpha1.ComponentSpec) (metas []brokerM
 		}
 		fqn := getPluginFQN(component)
 		var meta *brokerModel.PluginMeta
-		// delegate to the internal registry, if found there then use that
+		// delegate to the internal registry first, if found there then use that
 		if val, ok := internalRegistry[fqn.ID]; ok {
 			log.Info(fmt.Sprintf("Grabbing the meta.yaml for %s from the internal registry", fqn.ID))
 			meta = &val

--- a/pkg/internal_registry/registry.go
+++ b/pkg/internal_registry/registry.go
@@ -1,0 +1,57 @@
+package registry
+
+import (
+	brokerModel "github.com/eclipse/che-plugin-broker/model"
+)
+
+func InternalRegistry() map[string]brokerModel.PluginMeta {
+
+	return map[string]brokerModel.PluginMeta{
+		"eclipse/cloud-shell/nightly": {
+			APIVersion:  "v2",
+			Publisher:   "eclipse",
+			Description: "Cloud Shell provides an ability to use terminal widget like an editor.",
+			DisplayName: "Cloud Shell Editor",
+			ID:          "",
+			Icon:        "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+			Name:        "cloud-shell",
+			Spec: brokerModel.PluginMetaSpec{
+				Endpoints: []brokerModel.Endpoint{
+					{
+						Name:       "cloud-shell",
+						Public:     true,
+						TargetPort: 4444,
+						Attributes: map[string]string{
+							"protocol":           "http",
+							"type":               "ide",
+							"discoverable":       "false",
+							"secure":             "true",
+							"cookiesAuthEnabled": "true",
+						},
+					},
+				},
+				Containers: []brokerModel.Container{
+					{
+						Name:  "che-machine-exec",
+						Image: "quay.io/eclipse/che-machine-exec:nightly",
+						Ports: []brokerModel.ExposedPort{
+							{
+								ExposedPort: 4444,
+							},
+						},
+						Command: []string{
+							"/go/bin/che-machine-exec",
+							"--static",
+							"/cloud-shell",
+							"--url",
+							"127.0.0.1:4444",
+						},
+					},
+				},
+			},
+			Title:   "Cloud Shell Editor",
+			Type:    "Che Editor",
+			Version: "nightly",
+		},
+	}
+}


### PR DESCRIPTION
### What does this PR do?
This PR creates an internal registry that holds the cloud shell meta so that you won't have to deploy the plugin registry when using cloud shell.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16313

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested on crc with first setting env variable `REGISTRY_ENABLED = false`. As expected, the plugin registry wasn't deployed and when launching a cloud shell workspace it pulled from the internal registry and successfully started. When you try and start a workspace that uses theia, you will get an error saying something like `could not retrieve meta.yaml`

Then I turned on `REGISTRY_ENABLED = true` and ran `make deploy` and the plugin registry was successfully deployed. Tried to start a cloud shell workspace and it worked. Then I tried to start python-sample.yaml and it worked
